### PR TITLE
bump version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ndbc_api-{{ version }}.tar.gz
-  sha256: 28be2a3a45cf9355e9d38a60530193cdbd9aa30bce11da9ae99620554f722b2b
+  sha256: c3a25a3f357dd3e733fa0e5a3922e23c19daaa64ba59a5264aa67ed8566317a7
 
 
 build:
@@ -29,6 +29,7 @@ requirements:
     - urllib3
     - xarray
     - scipy
+    - h5netcdf
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ndbc-api" %}
-{% set version = "0.24.12.20.1" %}
+{% set version = "0.25.6.9.1" %}
 
 
 package:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

### Summary of core changes:

* Add support for [high frequency radar data](https://hfradar.ndbc.noaa.gov/) through THREDDS as native netcdf4
* Small adjustments to test formats
* Added documentation for the hfradar data mode
* Updated get_data to support hfradar as a mode with station_id used to pass one or more high frequency radar dataset identifiers (such as uswc_1km for United States West Coast data at a 1 kilometer resolution)

### Bugfixes:

* None noted; some documentation updates to better reflect what parameters are used.

### Future improvements:

* None noted.
